### PR TITLE
Forward original exception message when a require fails

### DIFF
--- a/lib/bundler/runtime.rb
+++ b/lib/bundler/runtime.rb
@@ -79,7 +79,7 @@ module Bundler
             rescue => e
               raise e if e.is_a?(LoadError) # we handle this a little later
               raise Bundler::GemRequireError.new e,
-                "There was an error while trying to load the gem '#{file}'."
+                "There was an error while trying to load the gem '#{file}': #{e}"
             end
           end
         rescue LoadError => e


### PR DESCRIPTION
When bundler failed to require a file it discarded the original message containing the reason why the require failed.

This change forwards the original message into the new message.

Example use case: jsonapi-resources referencing a nonexistent constant when loaded into a rails 5 project.
